### PR TITLE
fix: add dev editorType and inspect capability for figma plugin installation

### DIFF
--- a/src/cursor_mcp_plugin/manifest.json
+++ b/src/cursor_mcp_plugin/manifest.json
@@ -4,9 +4,13 @@
   "api": "1.0.0",
   "main": "code.js",
   "ui": "ui.html",
+  "capabilities": [
+    "inspect"
+  ],
   "editorType": [
     "figma",
-    "figjam"
+    "figjam",
+    "dev"
   ],
   "permissions": [],
   "networkAccess": {


### PR DESCRIPTION
Currently the figma plugin could not be installed due to: 
1. lack of `dev` editorType
2. `inspect` capability

Now those are patched to `manifest.json` and the figma plugin could be installed successfully.