### PR TITLE
fix: set layoutSizing FILL/HUG after appendChild in create_frame

### DIFF
--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -749,6 +749,23 @@ async function createFrame(params) {
   frame.resize(width, height);
   frame.name = name;
 
+  // Append to its parent BEFORE touching layout sizing. `layoutSizingHorizontal`/
+  // `layoutSizingVertical` = "FILL" is only legal once the node has an auto-layout
+  // parent (Figma reads frame.parent.layoutMode to validate it), so setting it while
+  // the frame is still unparented always throws.
+  if (parentId) {
+    const parentNode = await figma.getNodeByIdAsync(parentId);
+    if (!parentNode) {
+      throw new Error(`Parent node not found with ID: ${parentId}`);
+    }
+    if (!("appendChild" in parentNode)) {
+      throw new Error(`Parent node does not support children: ${parentId}`);
+    }
+    parentNode.appendChild(frame);
+  } else {
+    figma.currentPage.appendChild(frame);
+  }
+
   // Set layout mode if provided
   if (layoutMode !== "NONE") {
     frame.layoutMode = layoutMode;
@@ -764,13 +781,36 @@ async function createFrame(params) {
     frame.primaryAxisAlignItems = primaryAxisAlignItems;
     frame.counterAxisAlignItems = counterAxisAlignItems;
 
-    // Set layout sizing only when layoutMode is not NONE
-    frame.layoutSizingHorizontal = layoutSizingHorizontal;
-    frame.layoutSizingVertical = layoutSizingVertical;
-
     // Set item spacing only when layoutMode is not NONE
     frame.itemSpacing = itemSpacing;
   }
+
+  // Layout sizing is independent of layoutMode on `frame` itself: FILL requires an
+  // auto-layout *parent* (now guaranteed above), HUG requires `frame` to be a FRAME
+  // (always true here). Validate up front so a bad request fails with a clear message
+  // instead of Figma's generic API error.
+  if (layoutSizingHorizontal === "FILL" && frame.parent.layoutMode === "NONE") {
+    throw new Error(
+      "layoutSizingHorizontal: FILL is only valid when parentId points to an auto-layout frame"
+    );
+  }
+  if (layoutSizingVertical === "FILL" && frame.parent.layoutMode === "NONE") {
+    throw new Error(
+      "layoutSizingVertical: FILL is only valid when parentId points to an auto-layout frame"
+    );
+  }
+  if (layoutSizingHorizontal === "HUG" && frame.layoutMode === "NONE") {
+    throw new Error(
+      "layoutSizingHorizontal: HUG requires this frame's own layoutMode to be set (e.g. HORIZONTAL/VERTICAL), not NONE"
+    );
+  }
+  if (layoutSizingVertical === "HUG" && frame.layoutMode === "NONE") {
+    throw new Error(
+      "layoutSizingVertical: HUG requires this frame's own layoutMode to be set (e.g. HORIZONTAL/VERTICAL), not NONE"
+    );
+  }
+  frame.layoutSizingHorizontal = layoutSizingHorizontal;
+  frame.layoutSizingVertical = layoutSizingVertical;
 
   // Set fill color if provided
   if (fillColor) {
@@ -803,20 +843,6 @@ async function createFrame(params) {
   // Set stroke weight if provided
   if (strokeWeight !== undefined) {
     frame.strokeWeight = strokeWeight;
-  }
-
-  // If parentId is provided, append to that node, otherwise append to current page
-  if (parentId) {
-    const parentNode = await figma.getNodeByIdAsync(parentId);
-    if (!parentNode) {
-      throw new Error(`Parent node not found with ID: ${parentId}`);
-    }
-    if (!("appendChild" in parentNode)) {
-      throw new Error(`Parent node does not support children: ${parentId}`);
-    }
-    parentNode.appendChild(frame);
-  } else {
-    figma.currentPage.appendChild(frame);
   }
 
   return {

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -450,8 +450,8 @@ server.tool(
       .optional()
       .describe("Primary axis alignment for auto-layout frame. Note: When set to SPACE_BETWEEN, itemSpacing will be ignored as children will be evenly spaced."),
     counterAxisAlignItems: z.enum(["MIN", "MAX", "CENTER", "BASELINE"]).optional().describe("Counter axis alignment for auto-layout frame"),
-    layoutSizingHorizontal: z.enum(["FIXED", "HUG", "FILL"]).optional().describe("Horizontal sizing mode for auto-layout frame"),
-    layoutSizingVertical: z.enum(["FIXED", "HUG", "FILL"]).optional().describe("Vertical sizing mode for auto-layout frame"),
+    layoutSizingHorizontal: z.enum(["FIXED", "HUG", "FILL"]).optional().describe("Horizontal sizing mode. FILL requires parentId to point to an auto-layout frame (layoutMode != NONE); HUG requires this frame's own layoutMode to also be set (not NONE)"),
+    layoutSizingVertical: z.enum(["FIXED", "HUG", "FILL"]).optional().describe("Vertical sizing mode. FILL requires parentId to point to an auto-layout frame (layoutMode != NONE); HUG requires this frame's own layoutMode to also be set (not NONE)"),
     itemSpacing: z
       .number()
       .optional()


### PR DESCRIPTION
## Problem

`create_frame` set `layoutSizingHorizontal`/`layoutSizingVertical` on the
new frame *before* appending it to its parent. `FILL` is only valid once
the node has an auto-layout parent (Figma validates it against
`frame.parent.layoutMode`), so setting it while the frame was still
unparented silently failed to take effect — frames created with
`layoutSizingVertical: "FILL"` (or `HUG`) stayed at a fixed size instead
of growing/shrinking to fit their container or content.

The existing `setLayoutSizing` tool (for already-existing nodes) doesn't
have this bug, since by definition those nodes already have a parent.
`create_frame` just did the two steps in the wrong order.

## Fix

- Move `appendChild` (to the given `parentId`, or `figma.currentPage`)
  to happen immediately after the frame is created, before any sizing
  is touched.
- Explicitly validate `FILL`/`HUG` preconditions before setting them,
  so a bad combination throws a clear error instead of Figma's generic
  API error (or silently no-op'ing, which is what motivated tracking
  this down):
  - `FILL` requires the parent to be an auto-layout frame
    (`parent.layoutMode !== "NONE"`)
  - `HUG` requires the frame's own `layoutMode` to be set
    (`layoutMode !== "NONE"`)
- Updated the `layoutSizingHorizontal`/`layoutSizingVertical` MCP tool
  descriptions in `server.ts` to document these preconditions so an AI
  agent driving this tool is less likely to request an invalid
  combination in the first place.

## Test plan

- [ ] Create an auto-layout frame inside another auto-layout frame with
      `layoutSizingHorizontal: "FILL"` / `layoutSizingVertical: "FILL"`
      and confirm it now actually fills its parent (previously stayed
      fixed-size).
- [ ] Create a frame with `layoutMode` set and `layoutSizingVertical:
      "HUG"` and confirm it hugs its content.
- [ ] Confirm requesting `FILL` with no auto-layout parent, or `HUG`
      with `layoutMode: "NONE"`, now throws the new descriptive error
      instead of Figma's generic one.